### PR TITLE
Align linting with goreportcard.com

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,3 +7,14 @@ linters:
     - misspell
     - revive
     - staticcheck
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
+
+issues:
+  include:
+    - EXC0012
+    - EXC0013
+    - EXC0014
+    - EXC0015


### PR DESCRIPTION
This PR adds missing linting rules to make sure that we keep our 100% rating on https://goreportcard.com/report/github.com/toolctl/toolctl.