### PR TITLE
Add initial version of the upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ In the not-too-distant future, we will also provide an easy-to-use setup script 
 🎉 Successfully installed
 ```
 
+### Upgrade a tool
+
+```text
+❯ toolctl upgrade yq
+👷 Upgrading from v4.13.4 to v4.13.5 ...
+👷 Removing v4.13.4 ...
+👷 Installing v4.13.5 ...
+🎉 Successfully installed
+```
+
 ### Get information about tools
 
 ```text
@@ -61,12 +71,6 @@ In the not-too-distant future, we will also provide an easy-to-use setup script 
 [kustomize] ✨ kustomize v4.4.1: Template-free customization of Kubernetes configuration
 [kustomize] 🔄 kustomize v3.9.4 is installed at /usr/local/bin/kustomize
 ```
-
-## What will I soon be able to do with `toolctl`?
-
-- Upgrade your tools
-
-You have more ideas? Please [create an issue](https://github.com/toolctl/toolctl/issues/new) and let us know!
 
 ## Which tools does `toolctl` support?
 

--- a/internal/cmd/info_test.go
+++ b/internal/cmd/info_test.go
@@ -123,7 +123,6 @@ echo "v0.1.1"
 			},
 			preinstalledToolIsSymlinked: true,
 			cliArgs:                     []string{"toolctl-test-tool"},
-			wantErr:                     false,
 			wantOutRegex: `✨ toolctl-test-tool v0.1.1: toolctl test tool
 ✅ toolctl-test-tool v0.1.1 is installed at .+
 🔗 Symlinked from .+/symlinked-toolctl-test-tool
@@ -155,7 +154,7 @@ $`,
 
 		var preinstalledTempInstallDir string
 		if !cmp.Equal(tt.preinstalledTools, preinstalledTool{}) {
-			preinstalledTempInstallDir, err = install(
+			preinstalledTempInstallDir, err = preinstall(
 				t, toolctlAPI, tt.preinstalledTools, tt.preinstalledToolIsSymlinked,
 				originalPathEnv,
 			)

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -251,7 +251,7 @@ Error: installation failed: Expected v0.1.0, but installed v0.2.0
 
 		var preinstalledTempInstallDir string
 		if !cmp.Equal(tt.preinstalledTools, []preinstalledTool{}) {
-			preinstalledTempInstallDir, err = install(
+			preinstalledTempInstallDir, err = preinstall(
 				t, toolctlAPI, tt.preinstalledTools, tt.preinstalledToolIsSymlinked,
 				originalPathEnv,
 			)

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -78,7 +78,7 @@ toolctl-another-test-tool
 
 		var preinstalledTempInstallDir string
 		if !cmp.Equal(tt.preinstalledTools, preinstalledTool{}) {
-			preinstalledTempInstallDir, err = install(
+			preinstalledTempInstallDir, err = preinstall(
 				t, toolctlAPI, tt.preinstalledTools, tt.preinstalledToolIsSymlinked,
 				originalPathEnv,
 			)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -51,6 +51,7 @@ func NewRootCmd(toolctlWriter io.Writer, localAPIFS afero.Fs) *cobra.Command {
 	rootCmd.AddCommand(newInfoCmd(toolctlWriter, localAPIFS))
 	rootCmd.AddCommand(newInstallCmd(toolctlWriter, localAPIFS))
 	rootCmd.AddCommand(newListCmd(toolctlWriter, localAPIFS))
+	rootCmd.AddCommand(newUpgradeCmd(toolctlWriter, localAPIFS))
 	rootCmd.AddCommand(newVersionCmd(toolctlWriter))
 
 	// Hidden commands

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -25,6 +25,7 @@ Available Commands:
   info        Information about one or more tools
   install     Install one or more tools
   list        List the tools
+  upgrade     Upgrade one or more tools
   version     Display the version of toolctl
 
 Flags:

--- a/internal/cmd/shared_test.go
+++ b/internal/cmd/shared_test.go
@@ -100,36 +100,37 @@ type supportedTool struct {
 }
 
 type test struct {
-	name                        string
-	installDirNotFound          bool
-	installDirNotInPath         bool
-	installDirNotWritable       bool
-	supportedTools              []supportedTool
-	preinstalledTools           []preinstalledTool
-	preinstalledToolIsSymlinked bool
-	cliArgs                     []string
-	wantErr                     bool
-	wantOut                     string
-	wantOutRegex                string
-	wantFiles                   []APIFile
+	name                         string
+	installDirNotFound           bool
+	installDirNotInPath          bool
+	installDirNotWritable        bool
+	installDirNotPreinstalledDir bool
+	supportedTools               []supportedTool
+	preinstalledTools            []preinstalledTool
+	preinstalledToolIsSymlinked  bool
+	cliArgs                      []string
+	wantErr                      bool
+	wantOut                      string
+	wantOutRegex                 string
+	wantFiles                    []APIFile
 }
 
-func install(
+func preinstall(
 	t *testing.T, toolctlAPI api.ToolctlAPI, preinstalledTools []preinstalledTool,
 	preinstalledToolIsSymlinked bool, originalPathEnv string,
-) (tempInstallDir string, err error) {
-	tempInstallDir, err = ioutil.TempDir("", "toolctl-test-install-*")
+) (tmpPreinstallDir string, err error) {
+	tmpPreinstallDir, err = ioutil.TempDir("", "toolctl-test-preinstall-*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Setenv("PATH", os.ExpandEnv(tempInstallDir+":$PATH"))
+	err = os.Setenv("PATH", os.ExpandEnv(tmpPreinstallDir+":$PATH"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, preinstalledTool := range preinstalledTools {
 		err = os.WriteFile(
-			filepath.Join(tempInstallDir, preinstalledTool.name),
+			filepath.Join(tmpPreinstallDir, preinstalledTool.name),
 			[]byte(preinstalledTool.fileContents),
 			0755,
 		)
@@ -140,15 +141,15 @@ func install(
 
 	if preinstalledToolIsSymlinked {
 		err = os.Rename(
-			tempInstallDir+"/toolctl-test-tool",
-			tempInstallDir+"/symlinked-toolctl-test-tool",
+			tmpPreinstallDir+"/toolctl-test-tool",
+			tmpPreinstallDir+"/symlinked-toolctl-test-tool",
 		)
 		if err != nil {
 			t.Fatal(err)
 		}
 		err = os.Symlink(
-			tempInstallDir+"/symlinked-toolctl-test-tool",
-			tempInstallDir+"/toolctl-test-tool",
+			tmpPreinstallDir+"/symlinked-toolctl-test-tool",
+			tmpPreinstallDir+"/toolctl-test-tool",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/toolctl/toolctl/internal/api"
+)
+
+func newUpgradeCmd(
+	toolctlWriter io.Writer, localAPIFS afero.Fs,
+) *cobra.Command {
+	var upgradeCmd = &cobra.Command{
+		Use:   "upgrade TOOL... [flags]",
+		Short: "Upgrade one or more tools",
+		Example: `  # Upgrade a tool
+  toolctl upgrade minikube
+
+  # Upgrade multiple tools
+  toolctl upgrade kustomize k9s`,
+		Args: checkArgs(),
+		RunE: newRunUpgrade(toolctlWriter, localAPIFS),
+	}
+	return upgradeCmd
+}
+
+func newRunUpgrade(
+	toolctlWriter io.Writer, localAPIFS afero.Fs,
+) func(cmd *cobra.Command, args []string) (err error) {
+	return func(cmd *cobra.Command, args []string) (err error) {
+		toolctlAPI, err := api.New(localAPIFS, cmd, api.Remote)
+		if err != nil {
+			return err
+		}
+
+		allTools, err := ArgsToTools(args, runtime.GOOS, runtime.GOARCH, false)
+		if err != nil {
+			return fmt.Errorf(
+				"%w, try this instead:\n  toolctl upgrade %s",
+				err, strings.Join(stripVersionsFromArgs(args), " "),
+			)
+		}
+
+		installDir, err := checkInstallDir(toolctlWriter, allTools)
+		if err != nil {
+			return
+		}
+
+		for _, tool := range allTools {
+			err = upgrade(toolctlWriter, toolctlAPI, installDir, tool, allTools)
+			if err != nil {
+				return
+			}
+		}
+
+		return
+	}
+}
+
+func upgrade(
+	toolctlWriter io.Writer, toolctlAPI api.ToolctlAPI, installDir string,
+	tool api.Tool, allTools []api.Tool,
+) (err error) {
+	// Check if the tool is supported
+	_, err = api.GetToolMeta(toolctlAPI, tool)
+	if err != nil {
+		return
+	}
+
+	// Check if the tool is installed
+	installedToolPath, err := which(tool.Name)
+	if err != nil {
+		return
+	}
+	if installedToolPath == "" {
+		err = fmt.Errorf(
+			"%s is not installed", tool.Name,
+		)
+		return
+	}
+
+	// Check if the tool is installed in a different directory
+	if filepath.Dir(installedToolPath) != installDir {
+		err = fmt.Errorf(
+			"aborting: %s is currently installed in %s, not in %s",
+			tool.Name, filepath.Dir(installedToolPath), installDir,
+		)
+		return
+	}
+
+	// Get the latest version
+	latestVersion, err := api.GetLatestVersion(toolctlAPI, tool)
+	if err != nil {
+		return
+	}
+
+	// Get the installed version
+	toolMeta, err := api.GetToolMeta(toolctlAPI, tool)
+	if err != nil {
+		return
+	}
+	installedVersion, err := getInstalledVersion(
+		installedToolPath, toolMeta.VersionArgs,
+	)
+
+	// Check if the installed version is newer than the latest version
+	if installedVersion.GreaterThan(latestVersion) {
+		err = fmt.Errorf(
+			"%s is already at v%s, but the latest version is v%s",
+			tool.Name, installedVersion, latestVersion,
+		)
+		return
+	}
+
+	// Check if the installed version is the latest version
+	if installedVersion.Equal(latestVersion) {
+		fmt.Fprintln(
+			toolctlWriter,
+			prependToolName(tool, allTools, "✅ already up-to-date"),
+		)
+		return
+	}
+
+	// Check if the installed tool is symlinked
+	var fi fs.FileInfo
+	fi, err = os.Lstat(installedToolPath)
+	if err != nil {
+		return
+	}
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		var symlinkPath string
+		symlinkPath, err = filepath.EvalSymlinks(installedToolPath)
+		if err != nil {
+			return
+		}
+		err = fmt.Errorf(
+			"aborting: %s is symlinked from %s",
+			wrapInQuotesIfContainsSpace(installedToolPath),
+			wrapInQuotesIfContainsSpace(symlinkPath),
+		)
+		return
+	}
+
+	// Start the upgrade
+	fmt.Fprintln(
+		toolctlWriter, prependToolName(
+			tool, allTools, fmt.Sprintf(
+				"👷 Upgrading from v%s to v%s ...", installedVersion, latestVersion,
+			),
+		),
+	)
+
+	// Remove the installed tool
+	fmt.Fprintln(
+		toolctlWriter, prependToolName(
+			tool, allTools, fmt.Sprintf(
+				"👷 Removing v%s ...", installedVersion,
+			),
+		),
+	)
+	err = os.Remove(installedToolPath)
+	if err != nil {
+		return
+	}
+
+	// Install the latest version
+	err = install(toolctlWriter, toolctlAPI, installDir, tool, allTools)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/internal/cmd/upgrade_test.go
+++ b/internal/cmd/upgrade_test.go
@@ -1,0 +1,234 @@
+package cmd_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/viper"
+	"github.com/toolctl/toolctl/internal/cmd"
+)
+
+func TestUpgradeCmd(t *testing.T) {
+	usage := `Usage:
+  toolctl upgrade TOOL... [flags]
+
+Examples:
+  # Upgrade a tool
+  toolctl upgrade minikube
+
+  # Upgrade multiple tools
+  toolctl upgrade kustomize k9s
+
+Flags:
+  -h, --help   help for upgrade
+
+Global Flags:
+      --config string   path of the config file (default is $HOME/.config/toolctl/config.yaml)
+
+`
+
+	tests := []test{
+		{
+			name:    "no cli args",
+			cliArgs: []string{},
+			wantErr: true,
+			wantOut: `Error: no tool specified
+` + usage,
+		},
+		{
+			name: "supported tool",
+			preinstalledTools: []preinstalledTool{
+				{
+					name: "toolctl-test-tool",
+					fileContents: `#!/bin/sh
+echo "v0.1.0"
+`,
+				},
+			},
+			cliArgs: []string{"toolctl-test-tool"},
+			wantOut: `👷 Upgrading from v0.1.0 to v0.1.1 ...
+👷 Removing v0.1.0 ...
+👷 Installing v0.1.1 ...
+🎉 Successfully installed
+`,
+		},
+		{
+			name:    "supported tool with version",
+			cliArgs: []string{"toolctl-test-tool@0.1.0"},
+			wantErr: true,
+			wantOut: `Error: please don't specify a tool version, try this instead:
+  toolctl upgrade toolctl-test-tool
+`,
+		},
+		{
+			name: "multiple supported tools",
+			preinstalledTools: []preinstalledTool{
+				{
+					name: "toolctl-test-tool",
+					fileContents: `#!/bin/sh
+echo "v0.1.0"
+`,
+				},
+			},
+			cliArgs: []string{"toolctl-test-tool", "toolctl-test-tool"},
+			wantOut: `[toolctl-test-tool] 👷 Upgrading from v0.1.0 to v0.1.1 ...
+[toolctl-test-tool] 👷 Removing v0.1.0 ...
+[toolctl-test-tool] 👷 Installing v0.1.1 ...
+[toolctl-test-tool] 🎉 Successfully installed
+[toolctl-test-tool] ✅ already up-to-date
+`,
+		},
+		{
+			name: "supported tool, latest version already installed",
+			preinstalledTools: []preinstalledTool{
+				{
+					name: "toolctl-test-tool",
+					fileContents: `#!/bin/sh
+echo "v0.1.1"
+`,
+				},
+			},
+			cliArgs: []string{"toolctl-test-tool"},
+			wantOut: `✅ already up-to-date
+`,
+		},
+		{
+			name:    "supported tool, not installed",
+			cliArgs: []string{"toolctl-test-tool"},
+			wantErr: true,
+			wantOut: `Error: toolctl-test-tool is not installed
+`,
+		},
+		{
+			name: "supported tool, symlinked",
+			preinstalledTools: []preinstalledTool{
+				{
+					name: "toolctl-test-tool",
+					fileContents: `#!/bin/sh
+echo "v0.1.0"
+`,
+				},
+			},
+			preinstalledToolIsSymlinked: true,
+			cliArgs:                     []string{"toolctl-test-tool"},
+			wantErr:                     true,
+			wantOutRegex: `Error: aborting: .+ is symlinked from .+
+$`,
+		},
+		{
+			name:                         "supported tool, installed not in install dir",
+			installDirNotPreinstalledDir: true,
+			preinstalledTools: []preinstalledTool{
+				{
+					name: "toolctl-test-tool",
+					fileContents: `#!/bin/sh
+echo "v0.1.0"
+`,
+				},
+			},
+			preinstalledToolIsSymlinked: true,
+			cliArgs:                     []string{"toolctl-test-tool"},
+			wantErr:                     true,
+			wantOutRegex: `Error: aborting: toolctl-test-tool is currently installed in .+, not in .+
+$`,
+		},
+		{
+			name:    "unsupported tool",
+			cliArgs: []string{"toolctl-unsupported-test-tool"},
+			wantErr: true,
+			wantOut: `Error: toolctl-unsupported-test-tool could not be found
+`,
+		},
+		{
+			name:    "unsupported tool with version",
+			cliArgs: []string{"toolctl-unsupported-test-tool@1.0.0"},
+			wantErr: true,
+			wantOut: `Error: please don't specify a tool version, try this instead:
+  toolctl upgrade toolctl-unsupported-test-tool
+`,
+		},
+	}
+
+	originalPathEnv := os.Getenv("PATH")
+
+	for _, tt := range tests {
+		toolctlAPI, apiServer, downloadServer, err := setupRemoteAPI(tt.supportedTools)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var tmpPreinstallDir string
+		if !cmp.Equal(tt.preinstalledTools, preinstalledTool{}) {
+			tmpPreinstallDir, err = preinstall(
+				t, toolctlAPI, tt.preinstalledTools, tt.preinstalledToolIsSymlinked,
+				originalPathEnv,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var tmpInstallDir string
+		if !tt.installDirNotPreinstalledDir {
+			tmpInstallDir = tmpPreinstallDir
+		} else {
+			tmpInstallDir, err = ioutil.TempDir("", "toolctl-test-install-*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = os.Setenv("PATH", os.ExpandEnv(tmpInstallDir+":$PATH"))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+
+			command := cmd.NewRootCmd(buf, toolctlAPI.GetLocalAPIFS())
+			command.SetArgs(append([]string{"upgrade"}, tt.cliArgs...))
+			viper.Set("RemoteAPIBaseURL", apiServer.URL)
+
+			var tmpInstallDirSuffix string
+			if tt.installDirNotFound {
+				tmpInstallDirSuffix = "-nonexistent"
+			}
+			viper.Set("InstallDir", tmpInstallDir+tmpInstallDirSuffix)
+
+			if !tt.installDirNotInPath {
+				os.Setenv("PATH", os.ExpandEnv(tmpInstallDir+":$PATH"))
+			}
+
+			// Redirect Cobra output
+			command.SetOut(buf)
+			command.SetErr(buf)
+
+			err := command.Execute()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			checkWantOut(t, tt, buf)
+		})
+
+		os.Setenv("PATH", originalPathEnv)
+
+		err = os.RemoveAll(tmpInstallDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !cmp.Equal(tt.preinstalledTools, preinstalledTool{}) {
+			err = os.RemoveAll(tmpPreinstallDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		apiServer.Close()
+		downloadServer.Close()
+	}
+}


### PR DESCRIPTION
This PR adds the initial version of the `upgrade` command, which currently supports upgrading one or more specified tools.

Closes #27.