### PR TITLE
Add DefaultAMD64 template func

### DIFF
--- a/internal/cmd/api_discover.go
+++ b/internal/cmd/api_discover.go
@@ -95,6 +95,9 @@ func discover(
 
 	// Parse the URL template
 	funcMap := template.FuncMap{
+		"DefaultAMD64": func(in string) string {
+			return strings.Replace(in, "amd64", "", 1)
+		},
 		"Title": strings.Title,
 		"X86_64": func(in string) string {
 			return strings.Replace(in, "amd64", "x86_64", 1)


### PR DESCRIPTION
Some projects don't define the architecture and just imply `amd64`. This PR adds support for these projects.