### PR TITLE
Fix install command in mounted volumes on containers

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -185,10 +185,16 @@ func install(
 
 	// Install the tool
 	installPath := filepath.Join(installDir, tool.Name)
-	err = os.Rename(extractedToolPath, installPath)
+    err = utils.MoveFile(extractedToolPath, installPath)
 	if err != nil {
 		return
 	}
+
+    //⋅Set⋅file⋅permissions⋅to⋅be⋅executable
+    err = utils.SetPermissions(installPath)
+    if err != nil {
+        return
+    }
 
 	installedVersion, err := getToolBinaryVersion(
 		installPath, toolMeta.VersionArgs,

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -185,16 +185,16 @@ func install(
 
 	// Install the tool
 	installPath := filepath.Join(installDir, tool.Name)
-    err = utils.MoveFile(extractedToolPath, installPath)
+	err = utils.MoveFile(extractedToolPath, installPath)
 	if err != nil {
 		return
 	}
 
-    //⋅Set⋅file⋅permissions⋅to⋅be⋅executable
-    err = utils.SetPermissions(installPath)
-    if err != nil {
-        return
-    }
+	//⋅Set⋅file⋅permissions⋅to⋅be⋅executable
+	err = utils.SetPermissions(installPath)
+	if err != nil {
+		return
+	}
 
 	installedVersion, err := getToolBinaryVersion(
 		installPath, toolMeta.VersionArgs,

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -13,18 +13,17 @@ func CopyFile(src, dest string) error {
 	if err != nil {
 		return fmt.Errorf("error opening source file: %s", err)
 	}
+	defer srcFile.Close()
 
 	// open destination file
 	destFile, err := os.Create(dest)
 	if err != nil {
-		srcFile.Close()
 		return fmt.Errorf("error opening destination file: %s", err)
 	}
 	defer destFile.Close()
 
 	// copy file
 	_, err = io.Copy(destFile, srcFile)
-	srcFile.Close()
 	if err != nil {
 		return fmt.Errorf("writing to destination file failed: %s", err)
 	}
@@ -34,7 +33,6 @@ func CopyFile(src, dest string) error {
 
 // MoveFile moves the file from the source to the destination
 func MoveFile(src, dest string) error {
-
 	// copy file
 	err := CopyFile(src, dest)
 	if err != nil {

--- a/internal/utils/fs.go
+++ b/internal/utils/fs.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// CopyFile copies the file from the source to the destination
+func CopyFile(src, dest string) error {
+	// open source file
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("error opening source file: %s", err)
+	}
+
+	// open destination file
+	destFile, err := os.Create(dest)
+	if err != nil {
+		srcFile.Close()
+		return fmt.Errorf("error opening destination file: %s", err)
+	}
+	defer destFile.Close()
+
+	// copy file
+	_, err = io.Copy(destFile, srcFile)
+	srcFile.Close()
+	if err != nil {
+		return fmt.Errorf("writing to destination file failed: %s", err)
+	}
+
+	return nil
+}
+
+// MoveFile moves the file from the source to the destination
+func MoveFile(src, dest string) error {
+
+	// copy file
+	err := CopyFile(src, dest)
+	if err != nil {
+		return fmt.Errorf("failed copying file: %s", err)
+	}
+
+	// delete source file
+	err = os.Remove(src)
+	if err != nil {
+		return fmt.Errorf("failed removing original file: %s", err)
+	}
+	return nil
+}
+
+// SetPermissions sets a file permissions to be executable
+func SetPermissions(src string) error {
+	err := os.Chmod(src, 0755)
+	if err != nil {
+		return fmt.Errorf("failed changing file permissions: %s", err)
+	}
+	return nil
+}

--- a/internal/utils/fs_test.go
+++ b/internal/utils/fs_test.go
@@ -1,0 +1,119 @@
+package utils_test
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/toolctl/toolctl/internal/utils"
+)
+
+var (
+	content = "this is a dummy file"
+)
+
+// Generates a random file path for the tests
+func generateFilePath() string {
+	b := make([]byte, 10)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return "/tmp/toolctl_" + hex.EncodeToString(b) + ".test"
+}
+
+// Creates a dummy test file for the tests
+func createDummyFile() (string, error) {
+	path := generateFilePath()
+	file, err := os.Create(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	file.WriteString(content)
+	return path, nil
+}
+
+// removes all created files in the tests
+func cleanup() {
+	files, err := filepath.Glob("/tmp/toolctl_*.test")
+	if err != nil {
+		panic(err)
+	}
+	for _, f := range files {
+		if err := os.Remove(f); err != nil {
+			panic(err)
+		}
+	}
+}
+
+// TestCopyFile tests if a file is correctly copied from source to destination
+func TestCopyFile(t *testing.T) {
+	sourceFilePath, err := createDummyFile()
+	if err != nil {
+		t.Errorf("failed to create the source file")
+	}
+	destFilePath := generateFilePath()
+	err = utils.CopyFile(sourceFilePath, destFilePath)
+	if err != nil {
+		t.Errorf("failed to copy file to destination")
+	}
+
+	destFileContent, err := ioutil.ReadFile(destFilePath)
+	if err != nil {
+		t.Errorf("failed to open destination file")
+	}
+	if strings.Compare(content, string(destFileContent)) != 0 {
+		t.Errorf("copied file content doesn't match the original")
+	}
+	cleanup()
+}
+
+// TestMoveFile tests if a file is correctly moved from source to destination
+func TestMoveFile(t *testing.T) {
+	sourceFilePath, err := createDummyFile()
+	if err != nil {
+		t.Errorf("failed to create the source file")
+	}
+	destFilePath := generateFilePath()
+	err = utils.MoveFile(sourceFilePath, destFilePath)
+	if err != nil {
+		t.Errorf("failed to move file to destination")
+	}
+
+	if _, err := os.Stat(sourceFilePath); os.IsExist(err) {
+		t.Error("original file was note removed")
+	}
+
+	destFileContent, err := ioutil.ReadFile(destFilePath)
+	if err != nil {
+		t.Errorf("failed to open destination file")
+	}
+	if strings.Compare(content, string(destFileContent)) != 0 {
+		t.Errorf("copied file content doesn't match the original")
+	}
+
+	cleanup()
+}
+
+func TestSetPermissions(t *testing.T) {
+	file, err := createDummyFile()
+	if err != nil {
+		t.Errorf("failed to create the file")
+	}
+	utils.SetPermissions(file)
+
+	stats, err := os.Stat(file)
+	if err != nil {
+		t.Errorf("failed to read file permissions")
+	}
+
+	if stats.Mode() != 0755 {
+		t.Errorf("permissions not set correctly")
+	}
+
+	cleanup()
+}

--- a/internal/utils/fs_test.go
+++ b/internal/utils/fs_test.go
@@ -19,7 +19,11 @@ func createOriginFile() (*os.File, error) {
 		return nil, err
 	}
 	defer file.Close()
-	file.WriteString(content)
+	_, err = file.WriteString(content)
+
+	if err != nil {
+		return nil, err
+	}
 
 	return file, nil
 }
@@ -104,7 +108,10 @@ func TestSetPermissions(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create the file")
 	}
-	utils.SetPermissions(file.Name())
+	err = utils.SetPermissions(file.Name())
+	if err != nil {
+		t.Errorf("failed to set file permissions")
+	}
 
 	stats, err := os.Stat(file.Name())
 	if err != nil {


### PR DESCRIPTION
When running the installation script with `os.Rename` on mounted volumes inside containers it fails.

To fix this, a new function was created that copies the content from the origin file to the destination file.