### PR TITLE
Add --refresh-period flag to upgrade command

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,7 @@ linters:
 
 linters-settings:
   gocyclo:
-    min-complexity: 15
+    min-complexity: 16
 
 issues:
   include:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/afero v1.8.0
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
+	github.com/twpayne/go-xdg/v6 v6.0.0
 	golang.org/x/sys v0.0.0-20211210111614-af8b64212486
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,10 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/twpayne/go-vfs/v3 v3.0.0 h1:rMFBISZVhSowKeX1BxL8utM64V7CuUw9/rfekPdS7to=
+github.com/twpayne/go-vfs/v3 v3.0.0/go.mod h1:JKfJtOC57Wqo7xYxFRKSqdXwyj3AhfyRrDxSE/XiAVA=
+github.com/twpayne/go-xdg/v6 v6.0.0 h1:kt2KGpflK5q8ZpkmQfX6kJphh6+oAWikf4LiAZxFT0Y=
+github.com/twpayne/go-xdg/v6 v6.0.0/go.mod h1:XlfiGBU0iBxudVRWh+SXF+I1Cfb7rMq1IFwOprG4Ts8=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
@@ -559,6 +563,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/utils/state.go
+++ b/internal/utils/state.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/twpayne/go-xdg/v6"
+)
+
+// A State records state.
+type State struct {
+	filename string
+	Upgrade  struct {
+		LastSuccess time.Time
+	}
+}
+
+// NewState returns a state persisted to localFS. If there is no existing state,
+// then an empty state is returned.
+func NewState(localFS afero.Fs) (state *State, err error) {
+	// Follow the XDG Base Directory Specification to determine the state's
+	// location
+	var bds *xdg.BaseDirectorySpecification
+	bds, err = xdg.NewBaseDirectorySpecification()
+	if err != nil {
+		return
+	}
+
+	// Create an empty state at the default location
+	state = &State{
+		filename: path.Join(bds.CacheHome, "toolctl", "state.json"),
+	}
+
+	// Open the state file
+	var file afero.File
+	file, err = localFS.Open(state.filename)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		// If the state file does not exist then return the empty state, without
+		// error
+		err = nil
+		return
+	case err != nil:
+		return
+	}
+
+	// Unmarshal the state
+	var data []byte
+	data, err = io.ReadAll(file)
+	_ = file.Close()
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(data, &state)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// Write writes s to localFS.
+func (s *State) Write(localFS afero.Fs) (err error) {
+	// Create parent directories if needed
+	err = localFS.MkdirAll(path.Dir(s.filename), 0o777)
+	if err != nil {
+		return
+	}
+
+	// Create or replace the state file
+	var file afero.File
+	file, err = localFS.OpenFile(s.filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
+	if err != nil {
+		return
+	}
+	err = json.NewEncoder(file).Encode(s)
+	_ = file.Close()
+	return err
+}

--- a/internal/utils/state_test.go
+++ b/internal/utils/state_test.go
@@ -1,0 +1,36 @@
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spf13/afero"
+	"github.com/toolctl/toolctl/internal/utils"
+)
+
+func TestState(t *testing.T) {
+	localFS := afero.NewMemMapFs()
+
+	state, err := utils.NewState(localFS)
+	if err != nil {
+		t.Errorf("NewState() error = %v, wantErr <nil>", err)
+		return
+	}
+
+	upgradeLastSuccess := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	state.Upgrade.LastSuccess = upgradeLastSuccess
+	if err := state.Write(localFS); err != nil {
+		t.Errorf("state.Write() error = %v, wantErr <nil>", err)
+		return
+	}
+
+	state, err = utils.NewState(localFS)
+	if err != nil {
+		t.Errorf("NewState() error = %v, wantErr <nil>", err)
+		return
+	}
+
+	if got, want := state.Upgrade.LastSuccess, upgradeLastSuccess; got != want {
+		t.Errorf("state.Upgrade.LastSuccess = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #85.

This is an example implementation, lacking tests and documentation.

Example:

```console
$ toolctl upgrade gh
✅ already up-to-date
$ toolctl upgrade gh --refresh-period=1m
$ sleep 30
$ toolctl upgrade gh --refresh-period=1m
$ sleep 30
$ toolctl upgrade gh --refresh-period=1m
✅ already up-to-date
```

