### PR TITLE
chore: update renovate configuration to extend recommended settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
   "automerge": true,


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` file. The change updates the configuration to use `"config:recommended"` instead of `"config:base"`.