### PR TITLE
chore: update renovate configuration to use best practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "config:best-practices"
   ],
   "automerge": true,
   "platformAutomerge": true,


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration file to adopt best practices for dependency management.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3-R3): Replaced `"config:recommended"` and `"helpers:pinGitHubActionDigests"` with `"config:best-practices"` in the `extends` array to align with improved guidelines.